### PR TITLE
Fix deprecation warnings and remove unused dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ rvm:
   - 2.3.1
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.3 DB=postgres
     - SOLIDUS_BRANCH=v2.4 DB=postgres
     - SOLIDUS_BRANCH=v2.5 DB=postgres
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
+    - SOLIDUS_BRANCH=v2.8 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v2.3 DB=mysql
     - SOLIDUS_BRANCH=v2.4 DB=mysql
     - SOLIDUS_BRANCH=v2.5 DB=mysql
     - SOLIDUS_BRANCH=v2.6 DB=mysql
     - SOLIDUS_BRANCH=v2.7 DB=mysql
+    - SOLIDUS_BRANCH=v2.8 DB=mysql
     - SOLIDUS_BRANCH=master DB=mysql

--- a/Gemfile
+++ b/Gemfile
@@ -1,20 +1,12 @@
 source "https://rubygems.org"
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-gem "solidus", github: "solidusio/solidus", branch: branch
+gem 'solidus', git: 'https://github.com/solidusio/solidus.git', branch: branch
 
-if branch == 'master' || branch >= "v2.0"
-  gem "rails-controller-testing", group: :test
+if ENV['DB'] == 'mysql'
+  gem 'mysql2', '~> 0.4.10'
 else
-  gem "rails_test_params_backport"
-  gem "rails", "~> 4.2.7"
-end
-
-case ENV['DB']
-when 'mysql'
-  gem 'mysql2'
-when 'postgres'
-  gem 'pg', '< 1.0'
+  gem 'pg', '~> 0.21'
 end
 
 group :development, :test do

--- a/app/controllers/spree/admin/legacy_return_authorizations_controller.rb
+++ b/app/controllers/spree/admin/legacy_return_authorizations_controller.rb
@@ -8,7 +8,7 @@ module Spree
 
       def fire
         @legacy_return_authorization.send("#{params[:e]}!")
-        flash[:success] = Spree.t(:legacy_return_authorization_updated)
+        flash[:success] = I18n.t('spree.legacy_return_authorization_updated')
         if SolidusSupport.solidus_gem_version < Gem::Version.new('2.0')
           redirect_to :back
         else

--- a/app/models/spree/legacy_return_authorization.rb
+++ b/app/models/spree/legacy_return_authorization.rb
@@ -92,7 +92,12 @@ module Spree
         end
 
         Adjustment.create(adjustable: order, amount: compute_amount, label: I18n.t('spree.legacy_rma_credit'), source: self)
-        order.recalculate
+
+        if Spree.solidus_gem_version >= Gem::Version.new('2.4.0')
+          order.recalculate
+        else
+          order.update!
+        end
 
         order.return if inventory_units.all?(&:returned?)
       end

--- a/app/models/spree/legacy_return_authorization.rb
+++ b/app/models/spree/legacy_return_authorization.rb
@@ -70,7 +70,7 @@ module Spree
     private
 
       def must_have_shipped_units
-        errors.add(:order, Spree.t(:has_no_shipped_units)) if order.nil? || !order.shipped_shipments.any?
+        errors.add(:order, I18n.t('spree.has_no_shipped_units')) if order.nil? || !order.shipped_shipments.any?
       end
 
       def generate_number
@@ -91,8 +91,8 @@ module Spree
           end
         end
 
-        Adjustment.create(adjustable: order, amount: compute_amount, label: Spree.t(:legacy_rma_credit), source: self)
-        order.update!
+        Adjustment.create(adjustable: order, amount: compute_amount, label: I18n.t('spree.legacy_rma_credit'), source: self)
+        order.recalculate
 
         order.return if inventory_units.all?(&:returned?)
       end

--- a/app/overrides/admin_legacy_return_authorizations.rb
+++ b/app/overrides/admin_legacy_return_authorizations.rb
@@ -5,8 +5,8 @@ Deface::Override.new(
   text: %q(
     <% if can? :display, Spree::LegacyReturnAuthorization %>
       <% if @order.legacy_return_authorizations.exists? %>
-        <li<%== ' class="active"' if current == 'Legacy Return Authorizations' %>>
-          <%= link_to_with_icon 'share', Spree.t(:legacy_return_authorizations), admin_order_legacy_return_authorizations_url(@order) %>
+        <li <%= 'class="active"' if current == 'Legacy Return Authorizations' %>>
+          <%= link_to_with_icon 'share', I18n.t("spree.legacy_return_authorizations"), admin_order_legacy_return_authorizations_url(@order) %>
         </li>
       <% end %>
     <% end %>

--- a/app/views/spree/admin/legacy_return_authorizations/_form.html.erb
+++ b/app/views/spree/admin/legacy_return_authorizations/_form.html.erb
@@ -2,10 +2,10 @@
   <table class="index">
     <thead>
       <tr data-hook="legacy_rma_header">
-        <th><%= Spree.t(:product) %></th>
-        <th><%= Spree.t(:quantity_shipped) %></th>
-        <th><%= Spree.t(:quantity_returned) %></th>
-        <th><%= Spree.t(:return_quantity) %></th>
+        <th><%= I18n.t('spree.product') %></th>
+        <th><%= I18n.t('spree.quantity_shipped') %></th>
+        <th><%= I18n.t('spree.quantity_returned') %></th>
+        <th><%= I18n.t('spree.return_quantity') %></th>
       </tr>
     </thead>
     <tbody>
@@ -33,23 +33,23 @@
   </table>
 
   <%= f.field_container :amount do %>
-    <%= f.label :amount, Spree.t(:amount) %> <span class="required">*</span><br />
+    <%= f.label :amount, I18n.t('spree.amount') %> <span class="required">*</span><br />
     <% if @legacy_return_authorization.received? %>
       <%= @legacy_return_authorization.display_amount %>
     <% else %>
-      <%= f.text_field :amount, {:style => 'width:80px;'} %> <%= Spree.t(:legacy_rma_value) %>: <span id="legacy_rma_value">0.00</span>
+      <%= f.text_field :amount, {:style => 'width:80px;'} %> <%= I18n.t('spree.legacy_rma_value') %>: <span id="legacy_rma_value">0.00</span>
       <%= f.error_message_on :amount %>
     <% end %>
   <% end %>
 
   <%= f.field_container :reason do %>
-    <%= f.label :reason, Spree.t(:reason) %>
+    <%= f.label :reason, I18n.t('spree.reason') %>
     <%= f.text_area :reason, {:style => 'height:100px;', :class => 'fullwidth'} %>
     <%= f.error_message_on :reason %>
   <% end %>
 
   <%= f.field_container :stock_location do %>
-    <%= f.label :stock_location, Spree.t(:stock_location) %>
+    <%= f.label :stock_location, I18n.t('spree.stock_location') %>
     <%= f.select :stock_location_id, Spree::StockLocation.active.to_a.collect{|l|[l.name, l.id]}, {:style => 'height:100px;', :class => 'fullwidth'} %>
     <%= f.error_message_on :reason %>
   <% end %>

--- a/app/views/spree/admin/legacy_return_authorizations/edit.html.erb
+++ b/app/views/spree/admin/legacy_return_authorizations/edit.html.erb
@@ -1,12 +1,12 @@
 <% content_for :page_actions do %>
   <li>
     <% if @legacy_return_authorization.can_receive? %>
-      <%= button_link_to Spree.t(:receive), fire_admin_order_legacy_return_authorization_url(@order, @legacy_return_authorization, :e => 'receive'), :method => :put, :data => { :confirm => Spree.t(:are_you_sure) }, :icon => 'download-alt' %>
+      <%= button_to I18n.t('spree.receive'), fire_admin_order_legacy_return_authorization_url(@order, @legacy_return_authorization, :e => 'receive'), :method => :put, :data => { :confirm => I18n.t('spree.are_you_sure') }, :icon => 'download-alt' %>
     <% end %>
   </li>
   <li>
     <% if @legacy_return_authorization.can_cancel? %>
-      <%= button_link_to Spree.t('actions.cancel'), fire_admin_order_legacy_return_authorization_url(@order, @legacy_return_authorization, :e => 'cancel'), :method => :put, :data => { :confirm => Spree.t(:are_you_sure) }, :icon => 'remove' %>
+      <%= button_to I18n.t('spree.actions.cancel'), fire_admin_order_legacy_return_authorization_url(@order, @legacy_return_authorization, :e => 'cancel'), :method => :put, :data => { :confirm => I18n.t('spree.are_you_sure') }, :icon => 'remove' %>
     <% end %>
   </li>
 <% end %>
@@ -14,7 +14,7 @@
 <%= render :partial => 'spree/admin/shared/order_tabs', :locals => { :current => 'Legacy Return Authorizations' } %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:legacy_return_authorization) %> <%= @legacy_return_authorization.number %> (<%= Spree.t(@legacy_return_authorization.state.downcase) %>)
+  <i class="fa fa-arrow-right"></i> <%= I18n.t('spree.legacy_return_authorization') %> <%= @legacy_return_authorization.number %> (<%= I18n.t(@legacy_return_authorization.state.downcase) %>)
 <% end %>
 
 
@@ -24,9 +24,9 @@
     <%= render :partial => 'form', :locals => { :f => f } %>
 
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= button Spree.t('actions.update'), 'repeat' %>
-      <span class="or"><%= Spree.t(:or) %></span>
-      <%= button_link_to Spree.t('actions.cancel'), admin_order_legacy_return_authorizations_url(@order), :icon => 'remove' %>
+      <%= button_to I18n.t('spree.actions.update'), 'repeat' %>
+      <span class="or"><%= I18n.t('spree.or') %></span>
+      <%= button_to I18n.t('spree.actions.cancel'), admin_order_legacy_return_authorizations_url(@order), :icon => 'remove' %>
     </div>
   </fieldset>
 <% end %>

--- a/app/views/spree/admin/legacy_return_authorizations/index.html.erb
+++ b/app/views/spree/admin/legacy_return_authorizations/index.html.erb
@@ -2,22 +2,22 @@
 
 <% content_for :page_actions do %>
   <% if can?(:display, Spree::Order) %>
-    <li><%= button_link_to Spree.t(:back_to_orders_list), spree.admin_orders_path, :icon => 'arrow-left' %></li>
+    <li><%= button_to I18n.t('spree.back_to_orders_list'), spree.admin_orders_path, :icon => 'arrow-left' %></li>
   <% end %>
 <% end %>
 
 <% content_for :page_title do %>
-  <i class="fa fa-arrow-right"></i> <%= Spree.t(:legacy_return_authorizations) %>
+  <i class="fa fa-arrow-right"></i> <%= I18n.t('spree.legacy_return_authorizations') %>
 <% end %>
 
 <% if @order.shipments.any?(&:shipped?) || @order.legacy_return_authorizations.any? %>
   <table class="index">
     <thead data-hook="legacy_rma_header">
       <tr>
-        <th><%= Spree.t(:legacy_rma_number) %></th>
-        <th><%= Spree.t(:status) %></th>
-        <th><%= Spree.t(:amount) %></th>
-        <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
+        <th><%= I18n.t('spree.legacy_rma_number') %></th>
+        <th><%= I18n.t('spree.status') %></th>
+        <th><%= I18n.t('spree.amount') %></th>
+        <th><%= "#{I18n.t('spree.date')}/#{I18n.t('spree.time')}" %></th>
         <th class="actions"></th>
       </tr>
     </thead>
@@ -25,7 +25,7 @@
       <% @legacy_return_authorizations.each do |legacy_return_authorization| %>
         <tr id="<%= spree_dom_id(legacy_return_authorization) %>" data-hook="legacy_rma_row" class="<%= cycle('odd', 'even')%>">
           <td><%= legacy_return_authorization.number %></td>
-          <td><%= Spree.t(legacy_return_authorization.state.downcase) %></td>
+          <td><%= I18n.t(legacy_return_authorization.state.downcase) %></td>
           <td><%= legacy_return_authorization.display_amount.to_html %></td>
           <td><%= pretty_time(legacy_return_authorization.created_at) %></td>
           <td class="actions">
@@ -43,6 +43,6 @@
   </table>
 <% else %>
   <div data-hook="legacy_rma_cannont_create" class="no-objects-found">
-    <%= Spree.t(:cannot_create_returns) %>
+    <%= I18n.t('spree.cannot_create_returns') %>
   </div>
 <% end %>

--- a/lib/spree_legacy_return_authorizations/factories.rb
+++ b/lib/spree_legacy_return_authorizations/factories.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :legacy_return_authorization, class: Spree::LegacyReturnAuthorization do
-    number '100'
-    amount 100.00
+    number { '100' }
+    amount { 100.00 }
     association(:order, factory: :shipped_order)
-    reason 'no particular reason'
-    state 'received'
+    reason { 'no particular reason' }
+    state { 'received' }
   end
 
   factory :new_legacy_return_authorization, class: Spree::LegacyReturnAuthorization do

--- a/solidus_legacy_return_authorizations.gemspec
+++ b/solidus_legacy_return_authorizations.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec-rails",  "~> 3.2"
   s.add_development_dependency "simplecov"
-  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "sqlite3", '~> 1.3.6'
   s.add_development_dependency "sass-rails"
   s.add_development_dependency "coffee-rails"
   s.add_development_dependency "capybara", "~> 2.1"

--- a/spec/models/spree/legacy_return_authorization_spec.rb
+++ b/spec/models/spree/legacy_return_authorization_spec.rb
@@ -106,7 +106,12 @@ describe Spree::LegacyReturnAuthorization do
       end
 
       it "should update order state" do
-        expect(order).to receive :recalculate
+        if Spree.solidus_gem_version >= Gem::Version.new('2.4.0')
+          expect(order).to receive :recalculate
+        else
+          expect(order).to receive :update!
+        end
+
         legacy_return_authorization.receive!
       end
 
@@ -154,7 +159,12 @@ describe Spree::LegacyReturnAuthorization do
       end
 
       it "should NOT raise an error when no stock item exists in the stock location" do
-        inventory_unit.find_stock_item.discard
+        if Spree.solidus_gem_version >= Gem::Version.new('2.5.0')
+          inventory_unit.find_stock_item.discard
+        else
+          inventory_unit.find_stock_item.destroy
+        end
+
         expect { legacy_return_authorization.receive! }.not_to raise_error
       end
 

--- a/spec/models/spree/legacy_return_authorization_spec.rb
+++ b/spec/models/spree/legacy_return_authorization_spec.rb
@@ -101,12 +101,12 @@ describe Spree::LegacyReturnAuthorization do
 
       it "should add credit for specified amount" do
         legacy_return_authorization.amount = 20
-        expect(Spree::Adjustment).to receive(:create).with(adjustable: order, amount: -20, label: Spree.t(:legacy_rma_credit), source: legacy_return_authorization)
+        expect(Spree::Adjustment).to receive(:create).with(adjustable: order, amount: -20, label: I18n.t('spree.legacy_rma_credit'), source: legacy_return_authorization)
         legacy_return_authorization.receive!
       end
 
       it "should update order state" do
-        expect(order).to receive :update!
+        expect(order).to receive :recalculate
         legacy_return_authorization.receive!
       end
 
@@ -154,7 +154,7 @@ describe Spree::LegacyReturnAuthorization do
       end
 
       it "should NOT raise an error when no stock item exists in the stock location" do
-        inventory_unit.find_stock_item.destroy
+        inventory_unit.find_stock_item.discard
         expect { legacy_return_authorization.receive! }.not_to raise_error
       end
 


### PR DESCRIPTION
This patch aims to replace the following in order to fix all deprecation warnings:

* `Spree.t` -> `I18n.t`
* `order.update!` -> `order.recalculate`
* `button_link_to` -> `button_to`
* `destroy` -> `discard`

It also removes some dependencies from the project's Gemfile as they were needed with versions prior to v2.0.

**Update (01/29/2019)**: Added Travis support for Solidus v2.8

**Update (01/30/2019)**: As per @kennyadsl's request, this PR also removes support for Solidus v2.3 as tomorrow (**01/31/19**) is the last day before reaching EOL; this patch should only be merged **past** the date previously mentioned.

**Update (02/06/2019)**: Replaced static attributes on factories for dynamic ones.